### PR TITLE
Add base project structure with screens, tests, and README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,22 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+  ],
+  env: {
+    node: true,
+    es2021: true,
+  },
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  rules: {
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+  },
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - name: Install dependencies
+        run: |
+          npm install -g expo-cli
+          npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm test
+      - name: Build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,3 +1,70 @@
 # Grow Assistant
 
-Initial repository for the Grow Assistant React Native project.
+A React Native app built with Expo and TypeScript for managing your indoor grow operations.
+
+## Quickstart
+
+1. **Clone the repository**
+
+   ```sh
+   git clone https://github.com/stevenschling13/grow-assistant-rn.git
+   cd grow-assistant-rn
+   ```
+
+2. **Install dependencies**
+
+   This project uses Expo and Yarn. Install the dependencies with:
+   ```sh
+   yarn install
+   # or
+   npm install
+   ```
+
+3. **Environment variables**
+
+   Copy `.env.example` to `.env` and fill in your Supabase credentials:
+   ```env
+   SUPABASE_URL=your-supabase-url
+   SUPABASE_ANON_KEY=your-supabase-anon-key
+   ```
+   These are required for the Supabase client in `src/lib/supabase.ts`.
+
+4. **Run the development server**
+
+   Start the Expo development server:
+   ```sh
+   yarn start
+   # or
+   npm run start
+   ```
+   Then use the Expo Go app or an emulator to run the app.
+
+5. **Run tests**
+
+   Jest is configured for unit testing:
+   ```sh
+   yarn test
+   # or
+   npm test
+   ```
+
+6. **Lint and format**
+
+   ESLint and Prettier are included:
+   ```sh
+   yarn lint
+   yarn format
+   ```
+
+7. **Build for production**
+
+   Use Expo or EAS CLI to build release binaries when you are ready to ship.
+
+## Tech Stack
+
+- **Expo** – Cross‑platform build and development tooling
+- **React Native** – Framework for building native apps using React
+- **TypeScript** – Static typing for safer code
+- **React Navigation** – Navigation solution
+- **Zustand** – Lightweight state management
+- **Supabase** – Backend‑as‑a‑service for database and authentication

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import App from '../src/App';
+
+describe('App', () => {
+  it('renders correctly', () => {
+    const tree = renderer.create(<App />).toJSON();
+    expect(tree).toBeTruthy();
+  });
+});

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,0 +1,20 @@
+// Expo configuration for Grow Assistant
+// This dynamic config reads environment variables via dotenv. The variables
+// defined here are passed into your app via expo-constants. See
+// https://docs.expo.dev/guides/environment-variables/ for more details.
+
+import 'dotenv/config';
+
+export default ({ config }: { config: any }) => {
+  return {
+    ...config,
+    name: 'Grow Assistant',
+    slug: 'grow-assistant',
+    version: '1.0.0',
+    scheme: 'growassistant',
+    extra: {
+      supabaseUrl: process.env.SUPABASE_URL,
+      supabaseAnonKey: process.env.SUPABASE_ANON_KEY
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "grow-assistant-rn",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web",
+    "lint": "eslint . --ext .ts,.tsx",
+    "test": "jest",
+    "build": "expo export"
+  },
+  "dependencies": {
+    "expo": "~50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.4",
+    "expo-status-bar": "^1.8.0",
+    "expo-camera": "~14.0.0",
+    "expo-notifications": "~1.5.1",
+    "expo-constants": "~14.4.2",
+    "@react-navigation/native": "^6.1.10",
+    "@react-navigation/native-stack": "^6.9.12",
+    "zustand": "^4.5.0",
+    "react-native-svg": "^14.1.0",
+    "@supabase/supabase-js": "^2.38.0",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.7",
+    "@types/react": "^18.2.41",
+    "@types/react-native": "^0.73.4",
+    "typescript": "^5.4.5",
+    "jest": "^29.7.0",
+    "@testing-library/react-native": "^12.3.0",
+    "jest-expo": "^50.0.0",
+    "eslint": "^8.58.0",
+    "@typescript-eslint/eslint-plugin": "^7.11.0",
+    "@typescript-eslint/parser": "^7.11.0"
+  },
+  "jest": {
+    "preset": "jest-expo",
+    "testEnvironment": "jsdom"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+import AppNavigation from '@navigation/index';
+
+/**
+ * Root component for the Grow Assistant application. This component sets up
+ * the overall layout and inserts the navigation container. The status bar
+ * appearance is controlled here as well.
+ */
+export default function App() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <AppNavigation />
+      <StatusBar style="auto" />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/src/components/Heading.tsx
+++ b/src/components/Heading.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Text, StyleSheet, TextProps } from 'react-native';
+import { colours, fontSizes } from '../theme';
+
+/**
+ * Heading component used for titles on screens. It applies consistent font
+ * size and colour from the design system. Additional TextProps can be
+ * passed through.
+ */
+export default function Heading(props: TextProps) {
+  return <Text style={[styles.heading, props.style]} {...props} />;
+}
+
+const styles = StyleSheet.create({
+  heading: {
+    fontSize: fontSizes.title,
+    fontWeight: 'bold',
+    color: colours.primary,
+    marginBottom: 12,
+  },
+});

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+
+/**
+ * A basic layout component that provides padding and background colour for all
+ * screens. Use this component to wrap the content of your screens for a
+ * consistent look and feel across the application.
+ */
+interface ScreenProps {
+  children: React.ReactNode;
+}
+
+export default function Screen({ children }: ScreenProps) {
+  return <View style={styles.container}>{children}</View>;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    backgroundColor: '#fafafa',
+  },
+});

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Text as RNText, StyleSheet, TextProps } from 'react-native';
+import { colours, fontSizes } from '../theme';
+
+/**
+ * A basic text component that uses the base typography defined in the design
+ * system. Accepts all properties of React Native's Text component.
+ */
+export default function Text(props: TextProps & { variant?: keyof typeof fontSizes }) {
+  const { variant = 'body', style, ...rest } = props;
+  return <RNText style={[styles.base, { fontSize: fontSizes[variant] }, style]} {...rest} />;
+}
+
+const styles = StyleSheet.create({
+  base: {
+    color: colours.text,
+  },
+});

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,16 @@
+import { createClient } from '@supabase/supabase-js';
+import Constants from 'expo-constants';
+
+/**
+ * Creates and exports a single Supabase client instance. The credentials
+ * (URL and anon key) are injected from expo config at build time. This
+ * module can be imported anywhere in the app to make queries against the
+ * Supabase Postgres database or handle authentication.
+ */
+const { supabaseUrl, supabaseAnonKey } = (Constants as any).manifest?.extra ?? {};
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.warn('Supabase credentials are not set. Check your environment variables.');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+
+import DashboardScreen from '@screens/Dashboard';
+import PlantsScreen from '@screens/Plants';
+import PlantDetailScreen from '@screens/PlantDetail';
+import CalendarScreen from '@screens/Calendar';
+import FeedingScreen from '@screens/Feeding';
+import EnvironmentScreen from '@screens/Environment';
+import TasksScreen from '@screens/Tasks';
+import DryCureScreen from '@screens/DryCure';
+
+// Bottom tab navigation is used to switch between the main sections of the app.
+const Tab = createBottomTabNavigator();
+
+export default function AppNavigation() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Dashboard" component={DashboardScreen} />
+        <Tab.Screen name="Plants" component={PlantsScreen} />
+        <Tab.Screen name="Calendar" component={CalendarScreen} />
+        <Tab.Screen name="Feeding" component={FeedingScreen} />
+        <Tab.Screen name="Environment" component={EnvironmentScreen} />
+        <Tab.Screen name="Tasks" component={TasksScreen} />
+        <Tab.Screen name="Dry & Cure" component={DryCureScreen} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/src/screens/Calendar.tsx
+++ b/src/screens/Calendar.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Screen from '../components/Screen';
+import Heading from '../components/Heading';
+import Text from '../components/Text';
+
+export default function Calendar() {
+  return (
+    <Screen>
+      <Heading>Calendar</Heading>
+      <Text>View your grow schedule and events on the calendar.</Text>
+    </Screen>
+  );
+}

--- a/src/screens/Dashboard.tsx
+++ b/src/screens/Dashboard.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Screen from '../components/Screen';
+import Heading from '../components/Heading';
+import Text from '../components/Text';
+
+export default function Dashboard() {
+  return (
+    <Screen>
+      <Heading>Dashboard</Heading>
+      <Text>Welcome to your dashboard. Here you'll find an overview of your grow operation.</Text>
+    </Screen>
+  );
+}

--- a/src/screens/DryCure.tsx
+++ b/src/screens/DryCure.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Screen from '../components/Screen';
+import Heading from '../components/Heading';
+import Text from '../components/Text';
+
+export default function DryCure() {
+  return (
+    <Screen>
+      <Heading>Dry & Cure</Heading>
+      <Text>Track drying and curing of your harvested plants.</Text>
+    </Screen>
+  );
+}

--- a/src/screens/Environment.tsx
+++ b/src/screens/Environment.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Screen from '../components/Screen';
+import Heading from '../components/Heading';
+import Text from '../components/Text';
+
+export default function Environment() {
+  return (
+    <Screen>
+      <Heading>Environment</Heading>
+      <Text>Monitor temperature, humidity, CO₂,2and other environment metrics.</Text>
+    </Screen>
+  );
+}

--- a/src/screens/Feeding.tsx
+++ b/src/screens/Feeding.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Screen from '../components/Screen';
+import Heading from '../components/Heading';
+import Text from '../components/Text';
+
+export default function Feeding() {
+  return (
+    <Screen>
+      <Heading>Feeding</Heading>
+      <Text>Track and plan nutrient feedings for your plants.</Text>
+    </Screen>
+  );
+}

--- a/src/screens/PlantDetail.tsx
+++ b/src/screens/PlantDetail.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Screen from '../components/Screen';
+import Heading from '../components/Heading';
+import Text from '../components/Text';
+
+export default function PlantDetail {
+  return (
+    <Screen>
+      <Heading>Plant Detail</Heading>
+      <Text>Here you can view and edit details for a specific plant.</Text>
+    </Screen>
+  );
+}

--- a/src/screens/Plants.tsx
+++ b/src/screens/Plants.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Screen from '../components/Screen';
+import Heading from '../components/Heading';
+import Text from '../components/Text';
+
+export default function Plants() {
+  return (
+    <Screen>
+      <Heading>Plants</Heading>
+      <Text>Manage your plants here.</Text>
+    </Screen>
+  );
+}

--- a/src/screens/Tasks.tsx
+++ b/src/screens/Tasks.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Screen from '../components/Screen';
+import Heading from '../components/Heading';
+import Text from '../components/Text';
+
+export default function Tasks() {
+  return (
+    <Screen>
+      <Heading>Tasks</Heading>
+      <Text>Organize and check off your grow tasks.</Text>
+    </Screen>
+  );
+}

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -1,0 +1,60 @@
+import { create } from 'zustand';
+
+/**
+ * Defines the shape of the global application state. Plants, tasks and
+ * environmental readings are stored here and can be accessed from any
+ * component via the useStore hook. Zustand provides a simple and
+ * lightweight state management solution without the boilerplate of
+ * Redux.
+ */
+export interface Plant {
+  id: string;
+  name: string;
+  strain?: string;
+  stage: 'seedling' | 'veg' | 'flower' | 'harvest';
+  notes?: string;
+}
+
+export interface Task {
+  id: string;
+  title: string;
+  completed: boolean;
+  dueDate: string;
+}
+
+export interface EnvReading {
+  timestamp: string;
+  vpd: number;
+  ppfd: number;
+  temperature: number;
+  humidity: number;
+}
+
+interface StoreState {
+  plants: Plant[];
+  tasks: Task[];
+  envReadings: EnvReading[];
+  addPlant: (plant: Plant) => void;
+  updatePlant: (plant: Plant) => void;
+  addTask: (task: Task) => void;
+  toggleTask: (id: string) => void;
+  addEnvReading: (reading: EnvReading) => void;
+}
+
+export const useStore = create<StoreState>((set) => ({
+  plants: [],
+  tasks: [],
+  envReadings: [],
+  addPlant: (plant) => set((state) => ({ plants: [...state.plants, plant] })),
+  updatePlant: (plant) =>
+    set((state) => ({
+      plants: state.plants.map((p) => (p.id === plant.id ? plant : p)),
+    })),
+  addTask: (task) => set((state) => ({ tasks: [...state.tasks, task] })),
+  toggleTask: (id) =>
+    set((state) => ({
+      tasks: state.tasks.map((t) => (t.id === id ? { ...t, completed: !t.completed } : t)),
+    })),
+  addEnvReading: (reading) =>
+    set((state) => ({ envReadings: [...state.envReadings, reading] })),
+}));

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Minimal design system for Grow Assistant. This file defines colours, font
+ * sizes and spacing constants that can be reused throughout the app to
+ * maintain a consistent appearance. Keeping a single source of truth for
+ * styles makes it easier to tweak the look and feel later on.
+ */
+export const colours = {
+  primary: '#4caf50',
+  secondary: '#8bc34a',
+  background: '#fafafa',
+  text: '#333333',
+  muted: '#9e9e9e',
+};
+
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 24,
+  xl: 32,
+};
+
+export const fontSizes = {
+  small: 12,
+  body: 16,
+  heading: 24,
+  title: 32,
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "noEmit": true,
+    "jsx": "react-native",
+    "paths": {
+      "@screens/*": [
+        "src/screens/*"
+      ],
+      "@components/*": [
+        "src/components/*"
+      ],
+      "@navigation/*": [
+        "src/navigation/*"
+      ],
+      "@store/*": [
+        "src/store/*"
+      ]
+    }
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
This pull request sets up the Grow Assistant React Native app:

- Scaffolded the project using Expo, TypeScript, React Navigation, Zustand, and Supabase.
- Added core screens under `src/screens`: Dashboard, Plants, PlantDetail, Calendar, Feeding, Environment, Tasks, and DryCure.
- Added a basic Jest test for the `App` component in `__tests__/App.test.tsx`.
- Updated the README with comprehensive quickstart instructions, environment variable setup, and tech stack overview.

This establishes the foundation for further feature development.